### PR TITLE
Move closing `</div>` tag for container

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,6 @@
           </div>
           <div class="col-xs-12 col-sm-2"></div>
         </div>
-      </div>
         <div class="row">
           <div class="col-xs-12 col-md-2"></div>
           <div class="col-xs-12 col-sm-6 col-md-4">
@@ -96,6 +95,7 @@
           </div>
           <div class="col-xs-12 col-md-2"></div>
         </div>
+      </div>
     </section>
 
     <section id="section-photos">


### PR DESCRIPTION
Otherwise the div with `class="row"` makes the page too wide.

"row" divs should be inside "container" divs

Before change:
blue is the div, notice the horizontal scroll bar at the bottom and white space on the right, because the div is wider than the page
![row_too_wide](https://user-images.githubusercontent.com/4956308/212525964-f53ac197-d49f-426e-b685-ea82afa703eb.jpg)

After change:
div is now narrower, contained inside the "container" div, no more horizontal scroll bar
![row_normal](https://user-images.githubusercontent.com/4956308/212525975-1bf8a942-d7ff-4121-8271-4c618e1fbad9.jpg)
